### PR TITLE
既にjwt認証済みのuserはログイン画面に移動した場合、dashboard画面へリダイレクトされるように機能を更新

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,9 +23,23 @@ const App = () => {
     <>
       <BrowserRouter>
         <Routes>
-          {/* 認証不要のルート */}
-          <Route path="/signup" element={<SignUp />} />
-          <Route path="/login" element={<Login />} />
+          {/* 認証不要のルート (既に認証済みの場合、dashboardへリダイレクト) */}
+          <Route
+            path="/signup"
+            element={
+              <AuthGuard>
+                <SignUp />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/login"
+            element={
+              <AuthGuard>
+                <Login />
+              </AuthGuard>
+            }
+          />
           
           {/* 認証が必要なルート */}
           <Route

--- a/frontend/src/components/features/auth/AuthGuard.tsx
+++ b/frontend/src/components/features/auth/AuthGuard.tsx
@@ -33,7 +33,7 @@ export const AuthGuard = ({ children }: AuthGuardProps) => {
 
   // 認証確認中はローディング表示
   if (isAuthenticated === null) {
-    return <div>Loading...</div>;
+    return <Navigate to="/dashboard" />;
   }
 
   if (!isAuthenticated) {


### PR DESCRIPTION
webアプリを開いた際、jwtをcookieに保持しているのにも関わらずログイン画面からwebアプリが開始されてしまうことがあった。URLで /dashboard や /asset にすることで認証済みuserがアクセスできるページに移動することはできたが、それが一手間だと感じたため、jwtを保持しているuserはログイン画面からスタートしてしまった場合、/dashboardページへリダイレクトされるように機能を追加した。